### PR TITLE
Update Cal.com integration demo message and link

### DIFF
--- a/src/components/Scheduling.astro
+++ b/src/components/Scheduling.astro
@@ -18,14 +18,14 @@ import { site } from '../content/site';
         <!-- Demo Notice -->
         <div class="bg-blue-50 border-b border-blue-200 p-3 text-center">
           <p class="text-sm text-blue-800">
-            <span class="font-medium">Demo Integration:</span> Replace "your-calcom-username" with your actual Cal.com username
+            <span class="font-medium">Demo Integration:</span> This is a DEMO
           </p>
         </div>
         
         <!-- Cal.com Embed -->
         <div class="p-4">
           <cal-inline 
-            calLink="your-calcom-username/30min-consultation"
+            calLink="josh-byrom-d3jwh7/30min-consultation"
             style="width:100%;height:600px;overflow:hidden"
             config='{"layout": "month_view", "theme": "light", "hideEventTypeDetails": false, "styles": {"branding": {"brandColor": "#1a62db"}}}'>
           </cal-inline>


### PR DESCRIPTION
## Summary by Sourcery

Update the Cal.com integration demo by clarifying the notice message and pointing the embedded scheduler to a sample demo link

Enhancements:
- Change demo notice text to explicitly indicate a demo
- Update cal-inline component to use a sample Cal.com link for demonstration